### PR TITLE
Add missing isUserAuthor() into HasAuthorTrait

### DIFF
--- a/src/Traits/HasAuthor.php
+++ b/src/Traits/HasAuthor.php
@@ -11,6 +11,11 @@ trait HasAuthor
         return $this->belongsTo(config('volet-feature-board.user_model'));
     }
 
+    public function isUserAuthor(): bool
+    {
+        return ! str_starts_with($this->author_id, 'guest_');
+    }
+
     public function setAuthorId($authorId)
     {
         // If it's a guest ID, store it as is

--- a/tests/Unit/Traits/HasAuthorTest.php
+++ b/tests/Unit/Traits/HasAuthorTest.php
@@ -16,11 +16,6 @@ class ModelWithAuthor
     {
         $this->$relation = $value;
     }
-
-    public function isUserAuthor()
-    {
-        return ! str_starts_with($this->author_id, 'guest_');
-    }
 }
 
 test('can set author id for authenticated user', function () {


### PR DESCRIPTION
I'm currently using volet-feature-board and I'm experiencing an issue with the isUserAuthor() in every models since it's not declared anywhere.

I've added the function in the trait based on what I found in the HasAuthorTest fake class and replace the test to use the trait function.